### PR TITLE
update readme for new naming + standardize format + add temporary warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ workflows:
 jobs:  
   test-netstandard2.0:
     docker:
-      - image: microsoft/dotnet:2.0-sdk-jessie
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
     environment:
       ASPNETCORE_SUPPRESSSTATUSMESSAGES: "true" # suppresses annoying debug output from embedded HTTP servers in tests
     steps:
       - checkout
       - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.XamarinSdk -f netstandard2.0
-      - run: dotnet test -v=normal tests/LaunchDarkly.XamarinSdk.Tests/LaunchDarkly.XamarinSdk.Tests.csproj -f netcoreapp2.0
+      - run: dotnet test -v=normal tests/LaunchDarkly.XamarinSdk.Tests/LaunchDarkly.XamarinSdk.Tests.csproj -f netcoreapp2.1
 
   test-android:
     macos:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to the LaunchDarkly Client-Side SDK for Xamarin
+# Contributing to the LaunchDarkly Client-Side SDK for .NET
 
 LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/sdk/concepts/contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
 
 ## Submitting bug reports and feature requests
 
-The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/xamarin-client-sdk/issues) in the SDK repository. Bug reports and feature requests specific to this SDK should be filed in this issue tracker. The SDK team will respond to all newly filed issues within two business days.
+The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/dotnet-client-sdk/issues) in the SDK repository. Bug reports and feature requests specific to this SDK should be filed in this issue tracker. The SDK team will respond to all newly filed issues within two business days.
 
 ## Submitting pull requests
 
@@ -48,15 +48,3 @@ The equivalent test suites in Android or iOS must be run in an Android or iOS em
 You can run the mobile test projects from Visual Studio (the iOS tests require MacOS); there is also a somewhat complicated process for running them from the command line, which is what the CI build does (see `.circleci/config.yml`).
 
 Note that the mobile unit tests currently do not cover background-mode behavior or connectivity detection.
-
-### Packaging/releasing
-
-Run `./scripts/update-version.sh <VERSION>` to set the project version.
-
-Run `./scripts/release.sh` to build the project for all target frameworks and upload the package to NuGet. You must have already configured the necessary NuGet key locally.
-
-To verify that the package can be built without uploading it, run `./scripts/package.sh`.
-
-### Building a temporary package
-
-If you need to build a `.nupkg` for testing another application (in cases where linking directly to this project is not an option), run `./scripts/build-test-package.sh`. This will create a package with a unique version string in `./test-packages`. You can then set your other project to use `test-packages` as a NuGet package source.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<div style="border: 2px solid yellow; padding: 20px;">
 # This project is being renamed
 
 Xamarin is just one of several .NET-based platforms that this SDK supports. The **LaunchDarkly Client-Side SDK for Xamarin** is being renamed to the **LaunchDarkly Client-Side SDK for .NET**.
@@ -6,7 +5,6 @@ Xamarin is just one of several .NET-based platforms that this SDK supports. The 
 Future releases of the package on NuGet, starting with 2.0.0, will be named **LaunchDarkly.ClientSdk**. The old package name, **LaunchDarkly.XamarinSdk**, will have only maintenance/patch releases.
 
 The GitHub repository has been renamed from `launchdarkly/xamarin-client-sdk` to `launchdarkly/dotnet-client-sdk`. Links to the old repository are automatically redirected by GitHub.
-</div>
 
 # LaunchDarkly Client-Side SDK for .NET
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,69 @@
-LaunchDarkly Client-Side SDK for Xamarin
-===========================
+<div style="border: 2px solid yellow; padding: 20px;">
+# This project is being renamed
 
-[![CircleCI](https://circleci.com/gh/launchdarkly/xamarin-client-sdk/tree/master.svg?style=svg)](https://circleci.com/gh/launchdarkly/xamarin-client-sdk/tree/master)
+Xamarin is just one of several .NET-based platforms that this SDK supports. The **LaunchDarkly Client-Side SDK for Xamarin** is being renamed to the **LaunchDarkly Client-Side SDK for .NET**.
 
-LaunchDarkly overview
--------------------------
+Future releases of the package on NuGet, starting with 2.0.0, will be named **LaunchDarkly.ClientSdk**. The old package name, **LaunchDarkly.XamarinSdk**, will have only maintenance/patch releases.
+
+The GitHub repository has been renamed from `launchdarkly/xamarin-client-sdk` to `launchdarkly/dotnet-client-sdk`. Links to the old repository are automatically redirected by GitHub.
+</div>
+
+# LaunchDarkly Client-Side SDK for .NET
+
+[![NuGet (old)](https://img.shields.io/nuget/v/LaunchDarkly.XamarinSdk.svg?style=flat-square)](https://www.nuget.org/packages/LaunchDarkly.XamarinSdk/)
+[![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-client-sdk.svg?style=shield)](https://circleci.com/gh/launchdarkly/dotnet-client-sdk)
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/xamarin-client-sdk)
+
+The LaunchDarkly Client-Side SDK for .NET (formerly "LaunchDarkly SDK for Xamarin") is designed primarily for use by code that is deployed to an end user, such as in a desktop application or a smart device. It follows the client-side LaunchDarkly model for single-user contexts (much like our mobile or JavaScript SDKs). It is not intended for use in multi-user systems such as web servers and applications.
+
+On supported mobile platforms (Android and iOS), the SDK uses the Xamarin framework which allows .NET code to run on those devices. For that reason, the SDK was previously named after Xamarin. However, Xamarin is not the only way to run .NET code in a client-side context (see "Supported platforms" below), so the SDK now has a more general name.
+
+For using LaunchDarkly in *server-side* .NET applications, refer to our [Server-Side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk).
+
+## LaunchDarkly overview
+
 [LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!
-
+ 
 [![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
 
-Supported platforms
--------------------
+## Supported platforms
 
-This beta release is built for the following targets: Android 7.1, 8.0, 8.1; iOS 10; .NET Standard 1.6, 2.0. It has also been tested with Android 9/API 28 and iOS 12.1.
+This version of the SDK is built for the following targets:
 
-Note that if you are targeting .NET Framework, there is a [known issue](https://stackoverflow.com/questions/46788323/installing-a-netstandard-2-0-nuget-package-into-a-vs2015-net-4-6-1-project) in Visual Studio 2015 where it does not correctly detect compatibility with .NET Standard packages. This is not a problem in later versions of Visual Studio.
+* Xamarin Android 7.1, 8.0, and 8.1, which should also work with later versions of Android.
+* Xamarin iOS 10, for use with iOS 10 and higher.
+* .NET Standard 1.6 and 2.0, for use with any runtime platform that supports .NET Standard, or in portable .NET Standard library code.
 
-Getting started
------------
+The .NET Standard targets do not use any Xamarin packages and have no OS-specific code. This allows the SDK to be used in a desktop .NET Framework or .NET 5.0 application, or in a Xamarin MacOS application. However, due to the lack of OS-specific integration, SDK functionality will be limited in those environments: for instance, the SDK will not be able to detect whether networking is turned on or off.
 
-Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/client-side/xamarin#getting-started) for instructions on getting started with using the SDK.
+The .NET build tools should automatically load the most appropriate build of the SDK for whatever platform your application or library is targeted to.
 
-Learn more
------------
+## Getting started
 
-Check out our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/docs/xamarin-sdk-reference) or our [code-generated API documentation](https://launchdarkly.github.io/xamarin-client-sdk/).
+Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/client-side/xamarin) for instructions on getting started with using the SDK.
 
-Testing
--------
+## Learn more
 
+Check out our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/client-side/xamarin).
+
+The authoritative description of all types, properties, and methods is in the [generated API documentation](https://launchdarkly.github.io/xamarin-client-sdk/).
+
+## Testing
+ 
 We run integration tests for all our SDKs using a centralized test harness. This approach gives us the ability to test for consistency across SDKs, as well as test networking behavior in a long-running application. These tests cover each method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all behave correctly.
-
-Contributing
-------------
-
+ 
+## Contributing
+ 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
-About LaunchDarkly
------------
-
+## About LaunchDarkly
+ 
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
     * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
     * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
-* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
     * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides

--- a/tests/LaunchDarkly.XamarinSdk.Tests/LaunchDarkly.XamarinSdk.Tests.csproj
+++ b/tests/LaunchDarkly.XamarinSdk.Tests/LaunchDarkly.XamarinSdk.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>LaunchDarkly.XamarinSdk.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR is deliberately against the public repo rather than the private development repo, because we want these changes to be visible immediately while we're still preparing the 2.0.0 release. It's important to get people's attention about the renaming, because if they're only watching the `LaunchDarkly.XamarinSdk` package in NuGet for updates, and not following GitHub release notifications, they might never notice the release of the new `LaunchDarkly.ClientSdk` package.

I've copied _some_ of the wording from the version of README.md that's in the private repo, and applied our new standard formatting for the boilerplate content, but I've retained references to `LaunchDarkly.XamarinSdk` that are still correct for the public code as it is right now.

I also updated the CI configuration to use .NET Core 2.1 instead of 2.0— otherwise no builds would pass, since 2.0 is no longer available.